### PR TITLE
[Fix] Forcing plot coordinates calculation to (0, 0)

### DIFF
--- a/src/main/java/com/alpsbte/plotsystem/commands/CMD_Tpll.java
+++ b/src/main/java/com/alpsbte/plotsystem/commands/CMD_Tpll.java
@@ -110,7 +110,7 @@ public class CMD_Tpll extends BaseCommand {
             // Convert terra coordinates to plot relative coordinates
             CompletableFuture<double[]> plotCoords = plot != null ? PlotUtils.convertTerraToPlotXZ(plot, terraCoords) : null;
 
-            Bukkit.getLogger().log(Level.INFO, "doing TPLL to coords: " + plotCoords);
+
 
             if(plotCoords == null) {
                 player.sendMessage(Utils.ChatUtils.getAlertFormat(langUtil.get(sender, LangPaths.Message.Error.CANNOT_TELEPORT_OUTSIDE_PLOT)));
@@ -130,6 +130,13 @@ public class CMD_Tpll extends BaseCommand {
                 highestY = PlotWorld.MIN_WORLD_HEIGHT;
             }
 
+            Bukkit.getLogger().log(Level.INFO, "Doing TPLL to terraCoords: (lon: "
+                + terraCoords[0] + ", lat: "
+                + terraCoords[1] + ") "
+                + "To block coordinate: (x: "
+                + plotCoords.get()[0]
+                + ", y: " + plotCoords.get()[1] + ")"
+            );
             player.teleport(new Location(playerWorld, plotCoords.get()[0], highestY + 1, plotCoords.get()[1], player.getLocation().getYaw(), player.getLocation().getPitch()));
 
             DecimalFormat df = new DecimalFormat("##.#####");

--- a/src/main/java/com/alpsbte/plotsystem/commands/CMD_Tpll.java
+++ b/src/main/java/com/alpsbte/plotsystem/commands/CMD_Tpll.java
@@ -110,6 +110,8 @@ public class CMD_Tpll extends BaseCommand {
             // Convert terra coordinates to plot relative coordinates
             CompletableFuture<double[]> plotCoords = plot != null ? PlotUtils.convertTerraToPlotXZ(plot, terraCoords) : null;
 
+            Bukkit.getLogger().log(Level.INFO, "doing TPLL to coords: " + plotCoords);
+
             if(plotCoords == null) {
                 player.sendMessage(Utils.ChatUtils.getAlertFormat(langUtil.get(sender, LangPaths.Message.Error.CANNOT_TELEPORT_OUTSIDE_PLOT)));
                 return true;

--- a/src/main/java/com/alpsbte/plotsystem/core/menus/PlotTypeMenu.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/menus/PlotTypeMenu.java
@@ -82,7 +82,7 @@ public class PlotTypeMenu extends AbstractMenu {
         getMenu().getSlot(15).setItem(
                 new ItemBuilder(AlpsHeadUtils.getCustomHead(CustomHeads.CITY_INSPIRATION_MODE_BUTTON.getId()))
                         .setName(text(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.MenuTitle.SELECT_CITY_INSPIRATION_MODE), GOLD, BOLD)
-                                .append(text(" [", DARK_GRAY).append(text("BETA", RED).append(text("]", DARK_GRAY))))) // temporary BETA tag
+                                .append(text(" [", DARK_GRAY).append(text("WORK IN PROGRESS", RED).append(text("]", DARK_GRAY))))) // temporary BETA tag
                         .setLore(new LoreBuilder()
                                 .addLines(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.MenuDescription.SELECT_CITY_INSPIRATION_MODE))
                                 .build())
@@ -93,8 +93,8 @@ public class PlotTypeMenu extends AbstractMenu {
         int selectedPlotTypeSlot = 13;
         if(builder.getPlotTypeSetting() == PlotType.FOCUS_MODE)
             selectedPlotTypeSlot = 11;
-        if(builder.getPlotTypeSetting() == PlotType.CITY_INSPIRATION_MODE)
-            selectedPlotTypeSlot = 15;
+        // if(builder.getPlotTypeSetting() == PlotType.CITY_INSPIRATION_MODE)
+        //    selectedPlotTypeSlot = 15;
         getMenu().getSlot(selectedPlotTypeSlot - 9).setItem(new ItemBuilder(Material.LIME_STAINED_GLASS_PANE, 1).setName(empty()).build());
 
 
@@ -117,9 +117,10 @@ public class PlotTypeMenu extends AbstractMenu {
             reloadMenuAsync();
         }));
 
+        // WORK IN PROGRESS: Disabled city project of type
         getMenu().getSlot(15).setClickHandler(((clickPlayer, clickInformation) -> {
-            builder.setPlotTypeSetting(PlotType.CITY_INSPIRATION_MODE);
-            getMenuPlayer().playSound(getMenuPlayer().getLocation(), Utils.SoundUtils.DONE_SOUND, 1f, 1f);
+            // builder.setPlotTypeSetting(PlotType.CITY_INSPIRATION_MODE);
+            getMenuPlayer().playSound(getMenuPlayer().getLocation(), Utils.SoundUtils.ERROR_SOUND, 1f, 1f);
             reloadMenuAsync();
         }));
 

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/AbstractPlot.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/AbstractPlot.java
@@ -48,11 +48,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
-
-import static com.alpsbte.plotsystem.core.system.plot.world.PlotWorld.MAX_WORLD_HEIGHT;
-import static com.alpsbte.plotsystem.core.system.plot.world.PlotWorld.MIN_WORLD_HEIGHT;
 
 public abstract class AbstractPlot {
     public static final double PLOT_VERSION = 3;
@@ -67,6 +65,8 @@ public abstract class AbstractPlot {
 
     protected List<BlockVector2> outline;
     protected List<BlockVector2> blockOutline;
+    protected List<BlockVector2> shiftedOutline;
+
 
     public AbstractPlot(int id) {
         this.ID = id;
@@ -215,6 +215,22 @@ public abstract class AbstractPlot {
         }
         this.outline = locations;
         return locations;
+    }
+
+    public final List<BlockVector2> getShiftedOutline() throws SQLException, IOException {
+        if(this.shiftedOutline != null)
+            return this.shiftedOutline;
+
+        List<BlockVector2> outline = getOutline();
+        List<BlockVector2> shiftedOutlines = new LinkedList<>(outline);
+
+        BlockVector2 center = PlotUtils.getCenterFromOutline(outline);
+        for(int i = 0; i < shiftedOutlines.size(); i++)
+            shiftedOutlines.set(i, BlockVector2.at(outline.get(i).getX() - center.getX(), outline.get(i).getZ() - center.getZ()));
+
+
+        this.shiftedOutline = shiftedOutlines;
+        return shiftedOutline;
     }
 
     /**

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/AbstractPlot.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/AbstractPlot.java
@@ -51,6 +51,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 
+import static com.alpsbte.plotsystem.core.system.plot.world.PlotWorld.MAX_WORLD_HEIGHT;
+import static com.alpsbte.plotsystem.core.system.plot.world.PlotWorld.MIN_WORLD_HEIGHT;
+
 public abstract class AbstractPlot {
     public static final double PLOT_VERSION = 3;
 
@@ -166,6 +169,9 @@ public abstract class AbstractPlot {
             Clipboard clipboard = FaweAPI.load(getOutlinesSchematic());
             if (clipboard != null) {
                 Vector3 clipboardCenter = clipboard.getRegion().getCenter();
+
+                Bukkit.getLogger().log(Level.INFO, "Loading Clipboard Center at: " + BlockVector3.at(clipboardCenter.getX(), this.getWorld().getPlotHeightCentered(), clipboardCenter.getZ()));
+
                 return BlockVector3.at(clipboardCenter.getX(), this.getWorld().getPlotHeightCentered(), clipboardCenter.getZ());
             }
         } catch (IOException | SQLException ex) {

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/generator/AbstractPlotGenerator.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/generator/AbstractPlotGenerator.java
@@ -28,6 +28,7 @@ import com.alpsbte.plotsystem.PlotSystem;
 import com.alpsbte.plotsystem.core.system.Builder;
 import com.alpsbte.plotsystem.core.system.plot.AbstractPlot;
 import com.alpsbte.plotsystem.core.system.plot.Plot;
+import com.alpsbte.plotsystem.core.system.plot.TutorialPlot;
 import com.alpsbte.plotsystem.core.system.plot.utils.PlotType;
 import com.alpsbte.plotsystem.core.system.plot.utils.PlotUtils;
 import com.alpsbte.plotsystem.core.system.plot.world.CityPlotWorld;
@@ -77,9 +78,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.logging.Level;
 
 public abstract class AbstractPlotGenerator {
@@ -174,19 +173,14 @@ public abstract class AbstractPlotGenerator {
     protected void createPlotProtection() throws StorageException, SQLException, IOException {
         RegionContainer regionContainer = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionManager regionManager = regionContainer.get(BukkitAdapter.adapt(world.getBukkitWorld()));
+        List<BlockVector2> plotOutlines = plot instanceof TutorialPlot ? plot.getOutline() : plot.getShiftedOutline();
 
         if (regionManager != null) {
-            BlockVector2 center = BlockVector2.at(plot.getCenter().getX(), plot.getCenter().getZ()) ;
             // Create build region for plot from the outline of the plot
-            List<BlockVector2> plotOutlines = plot.getOutline();
-
-            Bukkit.getLogger().log(Level.INFO, "Configuring Plot outlines protection from:\n" + plotOutlines);
-            for(int i = 0; i < plotOutlines.size(); i++)
-                plotOutlines.set(i, BlockVector2.at(plotOutlines.get(i).getX() - center.getX(), plotOutlines.get(i).getZ() - center.getZ()));
-            Bukkit.getLogger().log(Level.INFO, "Configured Plot outlines protection to:\n" + plotOutlines);
-
             ProtectedRegion protectedBuildRegion = new ProtectedPolygonalRegion(world.getRegionName(), plotOutlines, PlotWorld.MIN_WORLD_HEIGHT, PlotWorld.MAX_WORLD_HEIGHT);
             protectedBuildRegion.setPriority(100);
+
+            Bukkit.getLogger().log(Level.INFO, "Configured Plot outlines protection to:\n" + protectedBuildRegion.getPoints() + "\n" + protectedBuildRegion);
 
             // Create protected plot region for plot
             World weWorld = new BukkitWorld(world.getBukkitWorld());
@@ -304,9 +298,7 @@ public abstract class AbstractPlotGenerator {
             World weWorld = new BukkitWorld(world.getBukkitWorld());
             try (EditSession editSession = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(world.getBukkitWorld()))) {
                 if (clearArea) {
-                    BlockVector3 center = BlockVector3.at(world.getPlot().getCenter().getBlockX(), world.getPlotHeight(), world.getPlot().getCenter().getBlockZ());
-                    Polygonal2DRegion polyRegion = new Polygonal2DRegion(weWorld,  world.getPlot().getOutline(), 0, PlotWorld.MAX_WORLD_HEIGHT);
-                    polyRegion.shift(BlockVector3.at(-center.getX(), 0, -center.getZ()));
+                    Polygonal2DRegion polyRegion = new Polygonal2DRegion(weWorld,  world.getPlot().getShiftedOutline(), 0, PlotWorld.MAX_WORLD_HEIGHT);
 
                     Bukkit.getLogger().log(Level.INFO, "Clearing plot region at:\n" + polyRegion);
 

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/CityPlotWorld.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/CityPlotWorld.java
@@ -101,13 +101,14 @@ public class CityPlotWorld extends PlotWorld {
     public int getWorldHeight() throws IOException {
         Clipboard clipboard = FaweAPI.load(getPlot().getOutlinesSchematic());
         int plotHeight = clipboard != null ? clipboard.getMinimumPoint().getBlockY() : MIN_WORLD_HEIGHT;
+        int heightThreshold = 50; // Additional height the plot use to save as schematic need to be included as a threshold
 
         // Plots created below min world height are not supported
-        if (plotHeight < MIN_WORLD_HEIGHT) throw new IOException("Plot height is not supported");
+        if (plotHeight + heightThreshold < MIN_WORLD_HEIGHT) throw new IOException("Plot height is not supported");
 
         // Move Y height to a usable value below 256 blocks
-        while (plotHeight >= 150) {
-            plotHeight -= 150;
+        while (plotHeight >= (heightThreshold + 100)) {
+            plotHeight -= (heightThreshold + 100);
         }
         return plotHeight;
     }

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/PlotWorld.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/PlotWorld.java
@@ -35,6 +35,7 @@ import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Polygonal2DRegion;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
@@ -50,13 +51,14 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 
 public class PlotWorld implements IWorld {
     public static final int PLOT_SIZE = 150;
     public static final int MAX_WORLD_HEIGHT = 256;
-    public static final int MIN_WORLD_HEIGHT = -69;
+    public static final int MIN_WORLD_HEIGHT = 5;
 
     private final MultiverseCore mvCore = PlotSystem.DependencyManager.getMultiverseCore();
     private final String worldName;
@@ -127,7 +129,7 @@ public class PlotWorld implements IWorld {
     @Override
     public boolean teleportPlayer(@NotNull Player player) {
         if (loadWorld() && plot != null) {
-            player.teleport(getSpawnPoint(plot instanceof TutorialPlot ? null : plot.getCenter()));
+            player.teleport(getSpawnPoint(plot instanceof TutorialPlot ? null : BlockVector3.at(0, plot.getCenter().getY(), 0)));
             return true;
         } else Bukkit.getLogger().log(Level.WARNING, "Could not teleport player " + player.getName() + " to world " + worldName + "!");
         return false;

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/PlotWorld.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/PlotWorld.java
@@ -56,7 +56,7 @@ import java.util.logging.Level;
 public class PlotWorld implements IWorld {
     public static final int PLOT_SIZE = 150;
     public static final int MAX_WORLD_HEIGHT = 256;
-    public static final int MIN_WORLD_HEIGHT = 5;
+    public static final int MIN_WORLD_HEIGHT = -69;
 
     private final MultiverseCore mvCore = PlotSystem.DependencyManager.getMultiverseCore();
     private final String worldName;

--- a/src/main/java/com/alpsbte/plotsystem/utils/items/CustomHeads.java
+++ b/src/main/java/com/alpsbte/plotsystem/utils/items/CustomHeads.java
@@ -39,7 +39,7 @@ public enum CustomHeads {
     GLOBE_HEAD("49973"),
     PLOT_TYPE_BUTTON("4159"),
     FOCUS_MODE_BUTTON("38199"),
-    CITY_INSPIRATION_MODE_BUTTON("38094");
+    CITY_INSPIRATION_MODE_BUTTON("24175");
 
     final String id;
 

--- a/src/main/resources/lang/en_GB.yml
+++ b/src/main/resources/lang/en_GB.yml
@@ -104,7 +104,7 @@ menu-title:
   select-plot-type: 'Select Plot Type'
   select-focus-mode: 'Select Focus Mode'
   select-local-inspiration-mode: 'Select Inspiration Mode'
-  select-city-inspiration-mode: 'Select City Inspiration Mode'
+  select-city-inspiration-mode: 'City Inspiration Mode'
   filter-by-country: 'Filter By Country'
   information: 'Info'
   tutorials: 'Tutorials'

--- a/src/main/resources/tutorial/tutorial_beginner.yml
+++ b/src/main/resources/tutorial/tutorial_beginner.yml
@@ -14,6 +14,8 @@ tutorial-id: 0
 tutorial-item-name: "BRICKS"
 tutorial-stages: 10
 
+# Tutorials plot offset: (x: 3693363, z: -4531335)
+
 # Spawn points for the player and the NPC (x, y, z, yaw, pitch)
 # To define the plot world spawn, use the key word ´plot´
 tutorial-worlds:
@@ -21,51 +23,51 @@ tutorial-worlds:
     spawn-player: '580.5, 42.0, 538.5, -65, 0'
     spawn-npc: '591.5, 43.0, 542.5, 115.8, 3.0'
   plot:
-    spawn-player: '3693357.5, 11.0, -4531324.5, 150, 0'
-    spawn-npc: '3693348.5, 11.0, -4531329.5, -60, 0'
+    spawn-player: '-6.5, 11.0, 11.5, 150, 0' # '3693357.5, 11.0, -4531324.5, 150, 0'
+    spawn-npc: '-15.5, 11.0, -6.5, -60, 0' # '3693348.5, 11.0, -4531329.5, -60, 0'
   spawn_end:
     spawn-player: '550.5, 53.0, 576.5, 135.3, 2.2'
     spawn-npc: '545.5, 52.0, 570.5, -39.3, -3.6'
 
 # Tip hologram coordinates (x, y, z)
 tip-hologram-coordinates:
-  - '3693351.5, 14, -4531334.5'
-  - '3693362.5, 21, -4531331.5'
-  - '3693363.5, 14, -4531330.5'
-  - '3693363.5, 17, -4531325.5'
-  - '3693358.5, 24, -4531334.5'
-  - '3693355.5, 14, -4531329.5'
-  - '3693365.5, 14, -4531325.5'
-  - '3693351.5, 14, -4531331.5'
-  - '3693365.5, 14, -4531325.5'
-  - '3693360.5, 22, -4531330.5'
-  - '3693356.5, 14, -4531329.5'
-  - '3693365.5, 14, -4531325.5'
-  - '3693355.5, 14, -4531329.5'
-  - '3693351.5, 14, -4531334.5'
+  - '-12.5, 14, 1.5' # '3693351.5, 14, -4531334.5'
+  - '-1.5, 21, 4.5' # '3693362.5, 21, -4531331.5'
+  - '0.5, 14, 5.5' # '3693363.5, 14, -4531330.5'
+  - '0.5, 17, 10.5' # '3693363.5, 17, -4531325.5'
+  - '-5.5, 24, 1.5' # '3693358.5, 24, -4531334.5'
+  - '-8.5, 14, 6.5' # '3693355.5, 14, -4531329.5'
+  - '2.5, 14, 10.5' # '3693365.5, 14, -4531325.5'
+  - '-12.5, 14, 4.5' # '3693351.5, 14, -4531331.5'
+  - '2.5, 14, 10.5' # '3693365.5, 14, -4531325.5'
+  - '-3.5, 22, 5.5' # '3693360.5, 22, -4531330.5'
+  - '-7.5, 14, 6.5' # '3693356.5, 14, -4531329.5'
+  - '2.5, 14, 10.5' # '3693365.5, 14, -4531325.5'
+  - '-8.5, 14, 6.5' # '3693355.5, 14, -4531329.5'
+  - '-12.5, 14, 1.5' # '3693351.5, 14, -4531334.5'
 
 # Documentation links which can be opened by clicking on ´Read More´ on tip holograms.
 documentation-links:
-  - 'https://docs.alps-bte.com/'
+  - 'https://asean.buildtheearth.asia/guide/builder-guide'
   - 'https://minecraft-worldedit.fandom.com/wiki///replace'
   - 'https://minecraft-worldedit.fandom.com/wiki///stack'
   - 'https://cdn.buildtheearth.net/static/tpll.mp4'
   - 'https://youtu.be/eYpry4CZ1uQ?si=qZe9i2eMIbzqS_AF&t=122'
   - 'https://youtu.be/VX7E7o9zLyI?si=krc0OPTMEjTUrtG7'
-  - 'https://alps-bte.com/en/'
+  - 'https://asean.buildtheearth.asia/'
 
 # -----------------------------------------------------
 # | Beginner Tutorial
 # -----------------------------------------------------
 beginner:
   # Outlines of the plot area the player can build and interact
-  plot-outlines: '3693351.0,-4531330.0|3693370.0,-4531324.0|3693375.0,-4531339.0|3693355.0,-4531346.0'
+  plot-outlines: '-12.0,5.0|7.0,11.0|12.0,-4.0|-8.0,-11.0'
   # Coordinates for the building outlines
   building-coordinates:
-    point-1: '3693354.0,-4531333.0'
-    point-2: '3693367.0,-4531328.0'
-    point-3: '3693370.0,-4531337.0'
-    point-4: '3693357.0,-4531342.0'
+    point-1: '-9.0,2.0'
+    point-2: '4.0,7.0'
+    point-3: '7.0,-2.0'
+    point-4: '-6.0,-7.0'
   # BaseBlock for the building outline
   base-block: 'WHITE_WOOL'
   base-block-id: 35
@@ -76,11 +78,11 @@ beginner:
   # Get material name from https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
   # NOTE: Material needs to be placeable block!
   window-points:
-    - '3693356.0;12.0;-4531332.0;minecraft:white_banner'
-    - '3693357.0;12.0;-4531332.0;minecraft:white_banner'
-    - '3693356.0;13.0;-4531332.0;minecraft:iron_trapdoor[half=bottom]'
-    - '3693357.0;13.0;-4531332.0;minecraft:iron_trapdoor[half=bottom]'
-    - '3693356.0;15.0;-4531332.0;minecraft:white_banner'
-    - '3693356.0;16.0;-4531332.0;minecraft:quartz_slab[type=top]'
+    - '-7.0;12.0;3.0;minecraft:white_banner'
+    - '-6.0;12.0;3.0;minecraft:white_banner'
+    - '-7.0;13.0;3.0;minecraft:iron_trapdoor[half=bottom]'
+    - '-6.0;13.0;3.0;minecraft:iron_trapdoor[half=bottom]'
+    - '-7.0;15.0;3.0;minecraft:white_banner'
+    - '-7.0;16.0;3.0;minecraft:quartz_slab[type=top]'
 
 config-version: 1.1


### PR DESCRIPTION
* fixes problem about plot system using terra coordinates which is very large; too large that bedrock support is impossible.

* plots is now shifted to the world's center (0, 0) before pasting on to a plot world

* then the plot region get shifted back saving a finished schematics

* bug: this breaks city project world which relies on the plot's exact coordinates

* todo: have an instanceof case to define city project plot and use normal coordinates function for it.